### PR TITLE
Centralizes MSBuild config and removes unused project URL

### DIFF
--- a/.github/coding-standard.md
+++ b/.github/coding-standard.md
@@ -3,21 +3,25 @@
 ## Project Architecture Standards
 
 ### MSBuild Configuration Pattern
+
 All projects follow a three-tier MSBuild configuration:
 
 **Directory.Packages.props** (Root level):
+
 - Central package management with `ManagePackageVersionsCentrally=true`
 - All package versions defined centrally for consistency
 - Separate dependency groups: Core, Test, Build & Analysis
 
 **Directory.Build.props** (Read BEFORE .csproj):
+
 - Host machine OS detection (Windows/macOS/Linux/Unix)
 - CI/CD environment detection (GitHub Actions, GitLab CI, Azure DevOps)
 - Global exclusions (Archive folders, Documentation folders)
 - Auto-configuration for Release builds in CI
 
 **Directory.Build.targets** (Read AFTER .csproj):
-- Project metadata variables: `$(Project_Name)`, `$(Project_Description)`, `$(Project_Copyright)`, `$(Project_Tags)`, `$(Project_Url)`
+
+- Project metadata variables: `$(Project_Name)`, `$(Project_Description)`, `$(Project_Copyright)`, `$(Project_Tags)`
 - Versioning: `$(Version_Full)`, `$(Version_Assembly)` with fallback defaults
 - NuGet packaging configuration with conditional generation
 - Documentation generation settings (XML docs)
@@ -25,20 +29,22 @@ All projects follow a three-tier MSBuild configuration:
 - Strict analyzer settings: `TreatWarningsAsErrors=true`, `AnalysisMode=AllEnabledByDefault`
 
 ### Project Structure Variables
+
 `.csproj` files use standardized variables instead of hardcoded values:
+
 ```xml
 <PropertyGroup>
   <Project_Name>Your.Library.Name</Project_Name>
   <Project_Description>Library description</Project_Description>
   <Project_Copyright>Your Name</Project_Copyright>
   <Project_Tags>keyword1;keyword2;keyword3</Project_Tags>
-  <Project_Url>https://github.com/username/repo</Project_Url>
 </PropertyGroup>
 ```
 
 ## Testing Standards
 
 ### Framework and Structure
+
 - **xUnit** as the testing framework
 - **FluentAssertions** v7.2.0 (for licensing compliance - v8+ requires commercial license)
 - Test project naming: `{ProjectName}.Tests`
@@ -46,7 +52,9 @@ All projects follow a three-tier MSBuild configuration:
 - Test method naming: `Method_Scenario_ExpectedResult`
 
 ### Test Organization Pattern
+
 Mirror your main project file structure in tests with strict 1:1 mapping:
+
 - Each main project file should have exactly one corresponding test file
 - Use identical naming: `ClassName.cs` → `ClassNameTests.cs`
 - For partial classes: `ByteArrayExtensions.PrimitiveTypeConversion.cs` → `ByteArrayExtensions.PrimitiveTypeConversionTests.cs`
@@ -55,6 +63,7 @@ Mirror your main project file structure in tests with strict 1:1 mapping:
 - Test file organization should exactly mirror source code organization for maintainability
 
 ### Test Patterns
+
 ```csharp
 // Standard test structure
 [Fact]
@@ -86,6 +95,7 @@ public void Method_InvalidInput_ThrowsException()
 ```
 
 ### Coverage Requirements
+
 - Minimum 80% code coverage enforced in CI/CD
 - Coverage collection via Coverlet with Cobertura format
 - Exclude test projects and third-party assemblies from coverage
@@ -93,11 +103,13 @@ public void Method_InvalidInput_ThrowsException()
 ## Build and CI/CD Standards
 
 ### Solution Structure
+
 - Use `.slnx` format for solution files (newer XML-based format)
 - Separate projects for library and tests
 - Optional documentation project using DocFX
 
 ### Build Commands Pattern
+
 ```bash
 # Standard workflow
 dotnet restore {ProjectName}.slnx
@@ -114,11 +126,13 @@ dotnet build -p:GeneratePackageOnBuild=true -p:Version_Full=X.Y.Z
 ```
 
 ### Documentation Generation
+
 - Use **DocFX** via dotnet tool manifest (`.config/dotnet-tools.json`)
 - Generate API documentation from XML comments
 - Deploy to GitHub Pages automatically
 
 ### Versioning Strategy
+
 - Semantic versioning: `{major}.{minor}.{patch}`
 - CI/CD auto-increments patch version based on Git tags
 - Version variables passed via MSBuild properties
@@ -127,18 +141,21 @@ dotnet build -p:GeneratePackageOnBuild=true -p:Version_Full=X.Y.Z
 ## Code Quality Standards
 
 ### Analyzer Configuration
+
 - Enable all .NET analyzers: `AnalysisMode=AllEnabledByDefault`
 - Treat warnings as errors: `TreatWarningsAsErrors=true`
 - Use Microsoft.CodeAnalysis.NetAnalyzers package
 - Include SourceLink for debugging support
 
 ### Language Features
+
 - Target latest .NET version (currently .NET 9)
 - Enable nullable reference types: `Nullable=enable`
 - Use latest C# language version: `LangVersion=latest`
 - Enable implicit usings: `ImplicitUsings=enable`
 
 ### Error Handling Philosophy
+
 - Throw meaningful exceptions with detailed context
 - Use `ArgumentNullException.ThrowIfNull()` for null checks
 - Provide alternative non-throwing methods when appropriate
@@ -147,12 +164,14 @@ dotnet build -p:GeneratePackageOnBuild=true -p:Version_Full=X.Y.Z
 ## Performance Considerations
 
 ### Modern .NET Patterns
+
 - Prefer `ReadOnlySpan<T>` and `Memory<T>` for performance-critical operations
 - Use `SequenceEqual()` for array/span comparisons
 - Implement `IDisposable` and `IAsyncDisposable` where appropriate
 - Leverage `ValueTask` for potentially synchronous async operations
 
 ### Resource Management
+
 - Dispose resources properly using `using` statements
 - Implement finalizers only when necessary
 - Use object pooling for frequently allocated objects when beneficial
@@ -160,12 +179,14 @@ dotnet build -p:GeneratePackageOnBuild=true -p:Version_Full=X.Y.Z
 ## NuGet Packaging Standards
 
 ### Package Metadata
+
 - Include package icon, license, and README files
 - Use meaningful package tags for discoverability
 - Set appropriate package output paths
 - Include symbol packages (`.snupkg`) for debugging
 
 ### Deployment Strategy
+
 - Deploy to NuGet.org on main branch merges
 - Automatic GitHub releases with generated notes
 - GitHub Pages deployment for documentation
@@ -174,6 +195,7 @@ dotnet build -p:GeneratePackageOnBuild=true -p:Version_Full=X.Y.Z
 ## GitHub Actions Workflow Pattern
 
 ### Job Structure
+
 1. **Version Calculation**: Auto-increment based on existing tags
 2. **Build/Test/Package**: Restore, build, test with coverage, package
 3. **Documentation**: Generate and deploy docs (main branch only)
@@ -181,6 +203,7 @@ dotnet build -p:GeneratePackageOnBuild=true -p:Version_Full=X.Y.Z
 5. **Release**: Create Git tags and GitHub releases
 
 ### Permissions Required
+
 ```yaml
 permissions:
   contents: write      # For tags and releases

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,7 +136,6 @@ Projects use these variables in `.csproj`:
 - `$(Project_Description)` - Package/assembly description
 - `$(Project_Copyright)` - Author/owner information
 - `$(Project_Tags)` - NuGet package tags
-- `$(Project_Url)` - Repository URL
 
 ## Development Workflows
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!-- Note : This is read BEFORE the initial project file -->
+
+  <!-- ==================== SELF REFERENCE ==================== -->
+  <ItemGroup>
+    <None Include="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(MSBuildThisFile)))" Pack="false" />
+  </ItemGroup>
+
+  <!-- ==================== UNIVERSAL ARTIFACTS CONFIGURATION ==================== -->
+  <PropertyGroup>
+    <!-- Central artifacts path configuration - can be overridden via command line -->
+    <!-- Use MSBuild's built-in artifacts system when available -->
+    <UseArtifactsOutput Condition="'$(UseArtifactsOutput)' == ''">true</UseArtifactsOutput>
+
+    <!-- Fallback artifacts path for explicit configuration -->
+    <ArtifactsPath Condition="'$(ArtifactsPath)' == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), 'output'))</ArtifactsPath>
+
+    <!-- Define standard subdirectories within artifacts -->
+    <ArtifactsPackagesPath>$([System.IO.Path]::Combine($(ArtifactsPath), 'packages'))</ArtifactsPackagesPath>
+    <ArtifactsTestsPath>$([System.IO.Path]::Combine($(ArtifactsPath), 'tests'))</ArtifactsTestsPath>
+    <ArtifactsBinPath>$([System.IO.Path]::Combine($(ArtifactsPath), 'bin'))</ArtifactsBinPath>
+    <ArtifactsObjPath>$([System.IO.Path]::Combine($(ArtifactsPath), 'obj'))</ArtifactsObjPath>
+
+    <PackageOutputPath>$(ArtifactsPackagesPath)</PackageOutputPath>
+
+    <TestResultsDirectory>$(ArtifactsTestsPath)</TestResultsDirectory>
+    <CoverageDirectory>$(ArtifactsTestsPath)</CoverageDirectory>
+    <CoverletOutput>$(ArtifactsTestsPath)</CoverletOutput>
+    <VSTestLogger>trx;LogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+    <VSTestResultsDirectory>$(ArtifactsTestsPath)</VSTestResultsDirectory>
+  </PropertyGroup>
+
+  <!-- ================== HOST MACHINE DETECTION ==================== -->
+  <PropertyGroup>
+    <IsHostMachineOSX>false</IsHostMachineOSX>
+    <IsHostMachineOSX Condition=" $([System.OperatingSystem]::IsMacOS()) ">true</IsHostMachineOSX>
+
+    <IsHostMachineLinux>false</IsHostMachineLinux>
+    <IsHostMachineLinux Condition=" $([System.OperatingSystem]::IsLinux()) ">true</IsHostMachineLinux>
+
+    <IsHostMachineWindows>false</IsHostMachineWindows>
+    <IsHostMachineWindows Condition=" $([System.OperatingSystem]::IsWindows()) ">true</IsHostMachineWindows>
+
+    <IsHostMachineUnix>false</IsHostMachineUnix>
+    <IsHostMachineUnix Condition=" $(IsHostMachineOSX) Or $(IsHostMachineLinux) ">true</IsHostMachineUnix>
+  </PropertyGroup>
+
+  <!-- ==================== CI/CD ==================== -->
+  <PropertyGroup>
+    <!-- see : https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild -->
+    <ContinuousIntegrationBuild Condition=" '$(TF_BUILD)'       == 'true' ">true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition=" '$(GITLAB_CI)'      == 'true' ">true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition=" '$(GITHUB_ACTIONS)' == 'true' ">true</ContinuousIntegrationBuild>
+
+    <!-- When building on CI, use Release configuration -->
+    <Configuration Condition=" '$(Configuration)' == '' AND '$(ContinuousIntegrationBuild)' == 'true' ">Release</Configuration>
+  </PropertyGroup>
+
+  <!-- ==================== ARCHIVED FILES ======================= -->
+  <ItemGroup>
+    <Compile Remove="**/Archive/**/*.*" />
+    <None Include="**/Archive/**/*.*" Pack="false" />
+  </ItemGroup>
+
+  <!-- ==================== DOCUMENTATION ======================= -->
+  <ItemGroup>
+    <Compile Remove="**/Documentation/**/*.*" />
+    <None Include="**/Documentation/**/*.*" Pack="false" />
+  </ItemGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!-- Note : This is read AFTER the initial project file -->
+
+  <!-- ==================== SELF REF ==================== -->
+  <ItemGroup>
+    <None Include="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(MSBuildThisFile)))" Pack="false" />
+  </ItemGroup>
+
+  <!-- ==================== VERSION ==================== -->
+  <Import Project="$(Version_Props_Path)" Condition="Exists('$(Version_Props_Path)')" />
+  <PropertyGroup>
+    <!-- Default version, when building locally -->
+    <Version_Full Condition=" '$(Version_Full)' == '' ">1.0.0</Version_Full>
+    <Version_Assembly Condition=" '$(Version_Assembly)' == '' ">$(Version_Full).0</Version_Assembly>
+
+    <!-- Apply Version parts according to packaging standards -->
+    <Version>$(Version_Full)</Version>
+    <PackageVersion>$(Version_Full)</PackageVersion>
+
+    <AssemblyInformationalVersion>$(Version_Full)</AssemblyInformationalVersion>
+    <AssemblyVersion>$(Version_Assembly)</AssemblyVersion>
+    <AssemblyFileVersion>$(Version_Assembly)</AssemblyFileVersion>
+
+    <ApplicationDisplayVersion>$(Version_Full)</ApplicationDisplayVersion>
+    <ApplicationVersion>$(Version_Revision)</ApplicationVersion>
+  </PropertyGroup>
+
+  <!-- ==================== LOGGING ==================== -->
+  <Target Name="PrintBuildInfo" BeforeTargets="CoreCompile">
+    <Message Importance="High" Text="Building : $(PackageId) - $(TargetFramework) - $(AssemblyFileVersion)" />
+    <Message Importance="High" Text="PackageOutputPath   : $(PackageOutputPath)" />
+  </Target>
+
+  <!-- ==================== PACK ==================== -->
+  <PropertyGroup>
+    <PackageIconPath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `icon.png`))</PackageIconPath>
+    <PackageLicencePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `LICENSE`))</PackageLicencePath>
+    <PackageReadMePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `README.md`))</PackageReadMePath>
+
+    <PackageIcon Condition="Exists('$(PackageIconPath)')">icon.png</PackageIcon>
+    <PackageLicense Condition="Exists('$(PackageLicencePath)')">LICENSE</PackageLicense>
+    <PackageReadmeFile Condition="Exists('$(PackageReadMePath)')">README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(PackageIconPath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageIconPath)')" />
+    <None Include="$(PackageReadMePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageReadMePath)')" />
+    <None Include="$(PackageLicencePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageLicencePath)')" />
+  </ItemGroup>
+</Project>

--- a/Plugin.BaseTypeExtensions/Directory.Build.props
+++ b/Plugin.BaseTypeExtensions/Directory.Build.props
@@ -7,41 +7,4 @@
     <None Include="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(MSBuildThisFile)))" Pack="false" />
   </ItemGroup>
 
-  <!-- ================== HOST MACHINE DETECTION ==================== -->
-  <PropertyGroup>
-    <IsHostMachineOSX>false</IsHostMachineOSX>
-    <IsHostMachineOSX Condition=" $([System.OperatingSystem]::IsMacOS()) ">true</IsHostMachineOSX>
-
-    <IsHostMachineLinux>false</IsHostMachineLinux>
-    <IsHostMachineLinux Condition=" $([System.OperatingSystem]::IsLinux()) ">true</IsHostMachineLinux>
-
-    <IsHostMachineWindows>false</IsHostMachineWindows>
-    <IsHostMachineWindows Condition=" $([System.OperatingSystem]::IsWindows()) ">true</IsHostMachineWindows>
-
-    <IsHostMachineUnix>false</IsHostMachineUnix>
-    <IsHostMachineUnix Condition=" $(IsHostMachineOSX) Or $(IsHostMachineLinux) ">true</IsHostMachineUnix>
-  </PropertyGroup>
-
-  <!-- ==================== CI/CD ==================== -->
-  <PropertyGroup>
-    <!-- see : https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild -->
-    <ContinuousIntegrationBuild Condition=" '$(TF_BUILD)'       == 'true' ">true</ContinuousIntegrationBuild>
-    <ContinuousIntegrationBuild Condition=" '$(GITLAB_CI)'      == 'true' ">true</ContinuousIntegrationBuild>
-    <ContinuousIntegrationBuild Condition=" '$(GITHUB_ACTIONS)' == 'true' ">true</ContinuousIntegrationBuild>
-
-    <!-- When building on CI, use Release configuration -->
-    <Configuration Condition=" '$(Configuration)' == '' AND '$(ContinuousIntegrationBuild)' == 'true' ">Release</Configuration>
-  </PropertyGroup>
-
-  <!-- ==================== ARCHIVED FILES ======================= -->
-  <ItemGroup>
-    <Compile Remove="**/Archive/**/*.*" />
-    <None Include="**/Archive/**/*.*" Pack="false" />
-  </ItemGroup>
-
-  <!-- ==================== DOCUMENTATION ======================= -->
-  <ItemGroup>
-    <Compile Remove="**/Documentation/**/*.*" />
-    <None Include="**/Documentation/**/*.*" Pack="false" />
-  </ItemGroup>
 </Project>

--- a/Plugin.BaseTypeExtensions/Directory.Build.targets
+++ b/Plugin.BaseTypeExtensions/Directory.Build.targets
@@ -14,30 +14,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <!-- ==================== VERSION ==================== -->
-  <PropertyGroup>
-    <!-- Default version, when building locally -->
-    <Version_Full Condition=" '$(Version_Full)' == '' ">1.0.0</Version_Full>
-    <Version_Assembly Condition=" '$(Version_Assembly)' == '' ">$(Version_Full).0</Version_Assembly>
-
-    <!-- Apply Version parts according to packaging standards -->
-    <Version>$(Version_Full)</Version>
-    <PackageVersion>$(Version_Full)</PackageVersion>
-
-    <AssemblyInformationalVersion>$(Version_Full)</AssemblyInformationalVersion>
-    <AssemblyVersion>$(Version_Assembly)</AssemblyVersion>
-    <AssemblyFileVersion>$(Version_Assembly)</AssemblyFileVersion>
-
-    <ApplicationDisplayVersion>$(Version_Full)</ApplicationDisplayVersion>
-    <ApplicationVersion>$(Version_Revision)</ApplicationVersion>
-  </PropertyGroup>
-
-  <!-- ==================== LOGGING ==================== -->
-  <Target Name="PrintBuildInfo" BeforeTargets="CoreCompile">
-    <Message Importance="High" Text="Building : $(PackageId) - $(TargetFramework) - $(AssemblyFileVersion)" />
-    <Message Importance="High" Text="PackageOutputPath   : $(PackageOutputPath)" />
-  </Target>
-
   <!-- ==================== GENERAL : VARIABLES ==================== -->
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -73,26 +49,10 @@
     <!-- Project_Description -->
     <PackageDescription>$(Project_Description)</PackageDescription>
 
-    <!-- Project_Url -->
-    <PackageProjectUrl>$(Project_Url)</PackageProjectUrl>
-
     <!-- Extra files and properties -->
     <PackageTags>$(Project_Tags)</PackageTags>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `../output/packages`))</PackageOutputPath>
-
-    <PackageIconPath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `../icon.png`))</PackageIconPath>
-    <PackageLicencePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `../LICENSE`))</PackageLicencePath>
-    <PackageReadMePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), `../README.md`))</PackageReadMePath>
-
-    <PackageIcon Condition="Exists('$(PackageIconPath)')">icon.png</PackageIcon>
-    <PackageLicense Condition="Exists('$(PackageLicencePath)')">LICENSE</PackageLicense>
-    <PackageReadmeFile Condition="Exists('$(PackageReadMePath)')">README.md</PackageReadmeFile>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="$(PackageIconPath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageIconPath)')" />
-    <None Include="$(PackageReadMePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageReadMePath)')" />
-    <None Include="$(PackageLicencePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageLicencePath)')" />
-  </ItemGroup>
 
   <!-- ==================== PACK : DOCUMENTATION ======================= -->
   <PropertyGroup>

--- a/Plugin.BaseTypeExtensions/Plugin.BaseTypeExtensions.csproj
+++ b/Plugin.BaseTypeExtensions/Plugin.BaseTypeExtensions.csproj
@@ -2,7 +2,6 @@
 
   <!-- ==================== VARIABLES ==================== -->
   <PropertyGroup>
-    <Project_Url>git@github.com:framinosona/Plugin.BaseTypeExtensions.git</Project_Url>
     <Project_Name>Plugin.BaseTypeExtensions</Project_Name>
     <Project_Tags>Plugin;BaseTypeExtensions;Tools;Toolkit</Project_Tags>
     <Project_Copyright>Francois Raminosona</Project_Copyright>


### PR DESCRIPTION
## Summary

- Centralizes common MSBuild props and targets for artifact paths, version logic, and packaging across all projects.
- Removes unused or redundant Project_Url property from MSBuild files and updates related documentation to reflect this cleanup.

## Details

- Introduces solution-level props and targets for artifact management, OS/environment detection, versioning, and packaging, reducing per-project duplication.
- Updates documentation to reflect the removal of Project_Url from coding standards and samples, ensuring consistency.

## Rationale

Improves maintainability and consistency by enforcing DRY configuration patterns and removing obsolete project properties. Lays groundwork for further CI/CD pipeline improvements and standardizes versioning/build logic across the repository.